### PR TITLE
Add javascript highlighting

### DIFF
--- a/extension/content-script/index.js
+++ b/extension/content-script/index.js
@@ -1,4 +1,5 @@
 import './extension.css';
+import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/gfm/gfm';
 import codeMirror from 'codemirror';
 import tabHandler from './tab-handler';


### PR DESCRIPTION
This adds javascript highlighting to the editor, but is probably not an ideal long term solution for supporting the full range of GH languages. I have not verified, but I imaging loading up every supported language would be slow.

Ideally, we would submit a PR to Codemirror that allowed for async loading of language support as specific fenced code blocks were detected, but looking at the code, that might be a pretty big undertaking. The alternative would be a simple hack that detected a failed load, loaded it async, then refreshed the rendering (might be much more doable).

Alternatively, we could create an options page where users were presented with a list of their most used languages, and placed checkboxes next to them.

In either case, we probably need to look into browserify partitioning: https://github.com/substack/browserify-handbook#partitioning
